### PR TITLE
fix the lost of big num

### DIFF
--- a/src/main/scala/com/github/chengpohi/edql/parser/json/JsonValParser.scala
+++ b/src/main/scala/com/github/chengpohi/edql/parser/json/JsonValParser.scala
@@ -110,7 +110,7 @@ trait JsonValParser {
 
     if (expr.getNumber != null) {
       checkParse(expr, expr.getNumber.getText)
-      return JsonCollection.Num(expr.getNumber.getText.toDouble)
+      return JsonCollection.Num(BigDecimal(expr.getNumber.getText))
     }
 
     if (expr.getBool != null) {


### PR DESCRIPTION
hi~, I have a commit to fix the big num problem.
I don't have all repository permissions, I can not compile the full plugin and verify, so I just run the unit tests. 
The unit test seems to pass
![image](https://github.com/user-attachments/assets/00a63836-0bbc-4a0b-9040-b505a4b12c7a)
this is my test json 
{
  "test": {
    "total": 7405486664228818988,
    "successful": 3.12,
    "failed": 0
  }
}